### PR TITLE
Removing 'uri' attribute from sample ontology_uri fields.

### DIFF
--- a/JSON_Data_Hub_Validator/schema/sample.json
+++ b/JSON_Data_Hub_Validator/schema/sample.json
@@ -6,10 +6,10 @@
     "type" : "object",
 
     "properties": {
-        "sample_ontology_uri" : {"type": "string", "format": "uri", "description": "Ontology term that links to sample ontology information. Depending on the biomaterial_type, will be either an UBERON or CL ontology term."},
+        "sample_ontology_uri" : {"type": "string", "description": "Ontology term that links to sample ontology information. Depending on the biomaterial_type, will be either an UBERON or CL ontology term."},
         "molecule" : {"type": "string", "description": "The type of molecule that was extracted from the biological material. Include one of the following: total RNA, polyA RNA, cytoplasmic RNA, nuclear RNA, genomic DNA, protein, or other."},
         "disease" : {"type": "string", "description": "Free form field for more specific disease information. If dealing with a rare disease consider identifiability issues."},
-        "disease_ontology_uri" : {"type": "string", "format": "uri", "description": "Links to disease ontology information. If dealing with a rare disease consider identifiability issues. The NCI metathesaurus term C0277545 “Disease type AND/OR category unknown” should be used for unknown diseases. Phenotypes associated with the disease should be submitted as DISEASE_ONTOLOGY_URIs (if available) or in the free form DISEASE attribute."},
+        "disease_ontology_uri" : {"type": "string", "description": "Links to disease ontology information. If dealing with a rare disease consider identifiability issues. The NCI metathesaurus term C0277545 “Disease type AND/OR category unknown” should be used for unknown diseases. Phenotypes associated with the disease should be submitted as DISEASE_ONTOLOGY_URIs (if available) or in the free form DISEASE attribute."},
         "biomaterial_type" : {"type": "string", "enum":["Cell Line", "Primary Cell", "Primary Cell Culture", "Primary Tissue"], "description": ""}
     },
 

--- a/JSON_Data_Hub_Validator/validateHub.py
+++ b/JSON_Data_Hub_Validator/validateHub.py
@@ -79,7 +79,8 @@ def validateJson(jsonObj, schema_file, validate_epirr, is_loose_validation):
 
     #Semantic validation
     logging.getLogger().info('Validating Datasets object...')
-    validateDatasets(jsonObj['datasets'], is_loose_validation)
+    sample_list = jsonObj['samples'].keys()
+    validateDatasets(jsonObj['datasets'], sample_list, is_loose_validation)
     logging.getLogger().info('Datasets validation passed.')
 
     #EpiRR validation
@@ -89,11 +90,15 @@ def validateJson(jsonObj, schema_file, validate_epirr, is_loose_validation):
         logging.getLogger().info('EpiRR validation passed.')
 
 
-def validateDatasets(datasets, is_loose_validation):
+def validateDatasets(datasets, sample_list, is_loose_validation):
     """Validate that dataset objects properties are OK."""
 
     for dn in datasets:
         dataset = datasets[dn]
+
+        #Does the sample name exist in the 'samples' dictionary?
+        if dataset['sample_id'] not in sample_list:
+            logging.getLogger().error('Dataset is linked to an unknown sample_id. (sample_id="%s" does not exist in "samples" dictionary).' % (dataset['sample_id']))
 
         for track_type in dataset['browser']:
 


### PR DESCRIPTION
Removed uri attribute to ontology_uri fields as it creates validation error if the field contains more than one uri.