### PR TITLE
Log unicode string

### DIFF
--- a/version_metadata/utils.py
+++ b/version_metadata/utils.py
@@ -14,7 +14,7 @@ class Logger:
 	def __init__(self):
 		pass
 	def __call__(self, m):
-		sys.stderr.write('{0}'.format(m))
+		sys.stderr.write(u'{0}'.format(m))
 	def warn(self, m):
 		self.__call__(m)
 	def trystr(self, x):

--- a/version_metadata/validate_sample.py
+++ b/version_metadata/validate_sample.py
@@ -23,7 +23,7 @@ class SampleValidator(IHECJsonValidator):
 		self.sra = sra
 		self.xmljson = self.sra.obj_xmljson()
 		for (xml, attrs) in self.xmljson:
-			logger('\n#__normalizingTags:{0}\n'.format(attrs['title']))
+			logger(u'\n#__normalizingTags:{0}\n'.format(attrs['title']))
 			attrs['attributes'] = self.normalize_tags(attrs['attributes'])
 		logger("\n\n")
 


### PR DESCRIPTION
The two changes in this PR has nothing to do with how submissions are validated. This is a patch for errors like this:
```bash
Traceback (most recent call last):
  File "__main__.py", line 46, in <module>
    main(Config.sys())
  File "__main__.py", line 33, in main
    validate_sample.main(args)
  File "/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/validate_sample.py", line 61, in main
    v = SampleValidator(sra, ihec_validators)
  File "/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/validate_sample.py", line 27, in __init__
    logger('\n#__normalizingTags:{0}\n'.format(attrs['title']))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u03bc' in position 71: ordinal not in range(128)
```
Sometimes we have greek letters in the title like "[Homo sapiens male adult (21 year) T-cell primary cell treated with 7.5 μg/kg G-CSF for 4 days](https://www.encodeproject.org/experiments/ENCSR414IHC/)". It seems titles like that are valid for JSON and XML schema. The error above only complains about outputting messages. And this seems to be a problem for python2 and python3 strings are by default unicode strings.