### PR TITLE
Small fix: Change molecule_ontology_curie type to 'array'

### DIFF
--- a/schemas/json/experiment.json
+++ b/schemas/json/experiment.json
@@ -11,7 +11,7 @@
         "experiment_type": {"type": "string", "description": "(Controlled Vocabulary) The assay target (e.g. ‘DNA Methylation’, ‘mRNA-Seq’, ‘smRNA-Seq’, 'Histone H3K4me1')."},
         "experiment_ontology_curie": {"type": "array", "items": {"type": "string", "pattern": "^(?!http|https|www)([a-z]*):[A-Za-z0-9]*", "description": "(Ontology: OBI) links to experiment ontology information."}},
         "library_strategy": {"type": "string", "description": "(Controlled Vocabulary) The assay used. These are defined within the SRA metadata specifications with a controlled vocabulary (e.g. ‘Bisulfite-Seq’, ‘RNA-Seq’, ‘ChIP-Seq’). For a complete list, see https://www.ebi.ac.uk/ena/submit/reads-library-strategy."},
-        "molecule_ontology_curie" : {"type": "string", "pattern": "^(?!http|https|www)([a-z]*):[A-Za-z0-9]*", "description": "(Ontology: SO) links to molecule ontology information."},
+        "molecule_ontology_curie" : {"type": "array", "pattern": "^(?!http|https|www)([a-z]*):[A-Za-z0-9]*", "description": "(Ontology: SO) links to molecule ontology information."},
         "molecule" : {"type": "string", "enum": ["total RNA", "polyA RNA", "cytoplasmic RNA", "nuclear RNA", "small RNA", "genomic DNA", "protein", "other"], "description": "(Controlled Vocabulary) The type of molecule that was extracted from the biological material. Include one of the following: total RNA, polyA RNA, cytoplasmic RNA, nuclear RNA, small RNA, genomic DNA, protein, or other."}
     },
     "required": ["library_strategy"],


### PR DESCRIPTION
Before 'molecule_ontology_curie' type was changed to an 'array' everywhere in schema except this one place.