### PR TITLE
Fix relative path for all schemas

### DIFF
--- a/schemas/json/1.0/dataset.json
+++ b/schemas/json/1.0/dataset.json
@@ -16,17 +16,17 @@
                 }
             ]
         },
-        "experiment_attributes": { "$ref": "file:./schemas/json/experiment.json" },
-        "analysis_attributes": { "$ref": "file:./schemas/json/analysis.json" },
+        "experiment_attributes": { "$ref": "file:../schemas/json/1.0/experiment.json" },
+        "analysis_attributes": { "$ref": "file:../schemas/json/1.0/analysis.json" },
         "browser": {
             "type": "object",
             "properties": {
-                "signal_unstranded": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "signal_forward": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "signal_reverse": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "peak_calls": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "methylation_profile":  {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "contigs":  {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"}
+                "signal_unstranded": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "signal_forward": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "signal_reverse": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "peak_calls": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "methylation_profile":  {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "contigs":  {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"}
             },
             "dependencies": {
                 "signal_forward": ["signal_reverse"],
@@ -36,9 +36,9 @@
         "download": {
             "type": "object",
             "properties": {
-                "rpkm_forward": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "rpkm_reverse": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"},
-                "rpkm_unstranded": {"$ref": "file:./schemas/json/1.0/dataset.json#/definitions/track"}
+                "rpkm_forward": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "rpkm_reverse": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"},
+                "rpkm_unstranded": {"$ref": "file:../schemas/json/1.0/dataset.json#/definitions/track"}
             },
             "additionalProperties": false,
             "dependencies": {

--- a/schemas/json/1.0/experiment.json
+++ b/schemas/json/1.0/experiment.json
@@ -18,14 +18,14 @@
 
     "allOf": [
         {"anyOf": [
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/chromatin_accessibility" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/bisulfite-seq" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/medip-seq" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/mre-seq" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/chip-seq" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/rna-seq" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/wgs" },
-            { "$ref": "file:./schemas/json/1.0/experiment.json#/definitions/other" }
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/chromatin_accessibility" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/bisulfite-seq" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/medip-seq" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/mre-seq" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/chip-seq" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/rna-seq" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/wgs" },
+            { "$ref": "file:../schemas/json/1.0/experiment.json#/definitions/other" }
         ]},
         {"anyOf": [
             {"required": ["experiment_ontology_uri"]},

--- a/schemas/json/1.0/hub.json
+++ b/schemas/json/1.0/hub.json
@@ -8,8 +8,8 @@
 
     "properties": {
         "hub_description": { "$ref": "#/definitions/hub_description", "description": "General information on the hub content." },
-        "datasets": { "type": "object", "additionalProperties": {"$ref": "file:./schemas/json/1.0/dataset.json"} },
-        "samples": { "type": "object", "additionalProperties": {"$ref": "file:./schemas/json/1.0/sample.json"} }
+        "datasets": { "type": "object", "additionalProperties": {"$ref": "file:../schemas/json/1.0/dataset.json"} },
+        "samples": { "type": "object", "additionalProperties": {"$ref": "file:../schemas/json/1.0/sample.json"} }
     },
     "required": ["hub_description", "datasets", "samples"],
 

--- a/schemas/json/1.0/sample.json
+++ b/schemas/json/1.0/sample.json
@@ -54,7 +54,7 @@
         "passage_if_expanded" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "If the primary cell has been expanded, the number of times the primary cell has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures. NA if no expansion."}}
       },
         "required": ["origin_sample", "origin_sample_ontology_uri", "cell_type", "markers", "passage_if_expanded"],
-        "allOf": [{ "$ref": "file:./schemas/json/1.0/sample.json#/definitions/donor" }]
+        "allOf": [{ "$ref": "file:../schemas/json/1.0/sample.json#/definitions/donor" }]
      }
     },
     {"if": {
@@ -73,7 +73,7 @@
         "passage_if_expanded" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "If the primary cell culture has been expanded, the number of times the primary cell culture has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures. NA if no expansion."}}
       },
         "required": ["origin_sample_ontology_uri", "origin_sample", "cell_type", "markers", "culture_conditions", "passage_if_expanded"],
-        "allOf": [{ "$ref": "file:./schemas/json/1.0/sample.json#/definitions/donor"}]
+        "allOf": [{ "$ref": "file:../schemas/json/1.0/sample.json#/definitions/donor"}]
      }
     },
     {"if": {
@@ -89,7 +89,7 @@
         "collection_method" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "The protocol for collecting the primary tissue."}}
       },
         "required": ["tissue_type", "tissue_depot", "collection_method"],
-        "allOf": [{ "$ref": "file:./schemas/json/1.0/sample.json#/definitions/donor" }]
+        "allOf": [{ "$ref": "file:../schemas/json/1.0/sample.json#/definitions/donor" }]
       }
     }
     ],

--- a/schemas/json/1.1/dataset.json
+++ b/schemas/json/1.1/dataset.json
@@ -16,17 +16,17 @@
                 }
             ]
         },
-        "experiment_attributes": { "$ref": "file:./schemas/json/1.1/experiment.json" },
-        "analysis_attributes": { "$ref": "file:./schemas/json/1.1/analysis.json" },
+        "experiment_attributes": { "$ref": "file:../schemas/json/1.1/experiment.json" },
+        "analysis_attributes": { "$ref": "file:../schemas/json/1.1/analysis.json" },
         "browser": {
             "type": "object",
             "properties": {
-                "signal_unstranded": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "signal_forward": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "signal_reverse": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "peak_calls": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "methylation_profile":  {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "contigs":  {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"}
+                "signal_unstranded": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "signal_forward": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "signal_reverse": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "peak_calls": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "methylation_profile":  {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "contigs":  {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"}
             },
             "dependencies": {
                 "signal_forward": ["signal_reverse"],
@@ -36,9 +36,9 @@
         "download": {
             "type": "object",
             "properties": {
-                "rpkm_forward": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "rpkm_reverse": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"},
-                "rpkm_unstranded": {"$ref": "file:./schemas/json/1.1/dataset.json#/definitions/track"}
+                "rpkm_forward": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "rpkm_reverse": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"},
+                "rpkm_unstranded": {"$ref": "file:../schemas/json/1.1/dataset.json#/definitions/track"}
             },
             "additionalProperties": false,
             "dependencies": {

--- a/schemas/json/1.1/experiment.json
+++ b/schemas/json/1.1/experiment.json
@@ -18,14 +18,14 @@
 
     "allOf": [
         {"anyOf": [
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/chromatin_accessibility" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/bisulfite-seq" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/medip-seq" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/mre-seq" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/chip-seq" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/rna-seq" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/wgs" },
-            { "$ref": "file:./schemas/json/1.1/experiment.json#/definitions/other" }
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/chromatin_accessibility" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/bisulfite-seq" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/medip-seq" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/mre-seq" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/chip-seq" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/rna-seq" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/wgs" },
+            { "$ref": "file:../schemas/json/1.1/experiment.json#/definitions/other" }
         ]},
         {"anyOf": [
             {"required": ["experiment_ontology_curie"]},

--- a/schemas/json/1.1/hub.json
+++ b/schemas/json/1.1/hub.json
@@ -8,8 +8,8 @@
 
     "properties": {
         "hub_description": { "$ref": "#/definitions/hub_description", "description": "General information on the hub content." },
-        "datasets": { "type": "object", "additionalProperties": {"$ref": "file:./schemas/json/1.1/dataset.json"} },
-        "samples": { "type": "object", "additionalProperties": {"$ref": "file:./schemas/json/1.1/sample.json"} }
+        "datasets": { "type": "object", "additionalProperties": {"$ref": "file:../schemas/json/1.1/dataset.json"} },
+        "samples": { "type": "object", "additionalProperties": {"$ref": "file:../schemas/json/1.1/sample.json"} }
     },
     "required": ["hub_description", "datasets", "samples"],
 

--- a/schemas/json/1.1/sample.json
+++ b/schemas/json/1.1/sample.json
@@ -54,7 +54,7 @@
         "passage_if_expanded" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "If the primary cell has been expanded, the number of times the primary cell has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures. NA if no expansion."}}
       },
         "required": ["cell_type"],
-        "allOf": [{ "$ref": "file:./schemas/json/1.1/sample.json#/definitions/donor" }]
+        "allOf": [{ "$ref": "file:../schemas/json/1.1/sample.json#/definitions/donor" }]
      }
     },
     {"if": {
@@ -73,7 +73,7 @@
         "passage_if_expanded" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "If the primary cell culture has been expanded, the number of times the primary cell culture has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures. NA if no expansion."}}
       },
         "required": ["cell_type", "culture_conditions"],
-        "allOf": [{ "$ref": "file:./schemas/json/1.1/sample.json#/definitions/donor"}]
+        "allOf": [{ "$ref": "file:../schemas/json/1.1/sample.json#/definitions/donor"}]
      }
     },
     {"if": {
@@ -89,7 +89,7 @@
         "collection_method" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "The protocol for collecting the primary tissue."}}
       },
         "required": ["tissue_type", "tissue_depot"],
-        "allOf": [{ "$ref": "file:./schemas/json/1.1/sample.json#/definitions/donor" }]
+        "allOf": [{ "$ref": "file:../schemas/json/1.1/sample.json#/definitions/donor" }]
       }
     }
     ],


### PR DESCRIPTION
This PR is to fix an error about the incorrect relative path while trying to run validateHub.py in IHEC_Data_Hub.

The relative path should point upwards in the hierarchy - therefore two dots should be used.

e.g.
`{"$ref": "file:../schemas/json/1.1/dataset.json"}`