### PR TITLE
Optional treatment in v1.0

### DIFF
--- a/schemas/json/1.0/sample.json
+++ b/schemas/json/1.0/sample.json
@@ -53,7 +53,7 @@
         }
     },
 
-    "required": ["sample_ontology_uri", "disease_ontology_uri", "disease", "biomaterial_provider", "biomaterial_type", "treatment"],
+    "required": ["sample_ontology_uri", "disease_ontology_uri", "disease", "biomaterial_provider", "biomaterial_type"],
 
     "allOf": [
     {


### PR DESCRIPTION
Removing requirement to provide sample.treatment attribute in v1.0, as this was not required for the historical submissions. 