### PR TITLE
Requiring input experiements for all ChIP-Seq experiments

### DIFF
--- a/schemas/json/2.0/experiment.json
+++ b/schemas/json/2.0/experiment.json
@@ -121,6 +121,7 @@
         "chip-seq": {
             "type": "object",
             "properties": {
+                "input" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "Identifier of input experiment"}},
                 "experiment_type" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "pattern": "^(ChIP-Seq Input)|(Histone H\\w+([\\./]\\w+)?)+$|(Transcription Factor)"}},
                 "experiment_target_tf" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "(Controlled vocabulary) An HGNC gene symbol"}},
                 "experiment_target_tf_modification" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "Post-transcriptional modification of the target protein"}},
@@ -146,8 +147,8 @@
                 "library_generation_fragment_size_range" : {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "description": "The fragment size range of the preparation."}}
             },
             "anyOf" : [
-                {"required": ["experiment_target_tf"]},
-                {"required": ["experiment_target_histone"]}
+                {"required": ["experiment_target_tf", "input"]},
+                {"required": ["experiment_target_histone", "input"]}
             ]
         },
 


### PR DESCRIPTION
Hello, 

As requested by Martin and Sita, I have added a required attribute in ChIP-Seq experiments, namely a link to the input experiment. 

Cheers,

Daniel