### PR TITLE
Fix utils not defined and clean up stdout

### DIFF
--- a/version_metadata/prevalidate.py
+++ b/version_metadata/prevalidate.py
@@ -68,7 +68,6 @@ class SchemaParser:
 			dependencies[defn] = SchemaParser.dependencies(js['definitions'][defn])
 
 		for subtype in js["allOf"]:
-			print(subtype)
 			biomaterial_type = subtype['if']['properties']['biomaterial_type']["const"][0]
 			if not biomaterial_type in ["Cell Line",  "Primary Cell", "Primary Cell Culture", "Primary Tissue"]:
 				utils.sanity_check_fail('__malformed-schema__:defnitions as not expected [2]')
@@ -112,7 +111,6 @@ class SchemaParser:
 		
 		ruleshash = dict()
 		for r in data.values():
-			print(r)
 			[e1, e2] = r["applies"]
 			if not e1 in ruleshash: ruleshash[e1] = dict()
 			if not e2 in ruleshash[e1]: ruleshash[e1][e2] = list()

--- a/version_metadata/validate_experiment.py
+++ b/version_metadata/validate_experiment.py
@@ -1,9 +1,10 @@
 from .sraparse import SRAParseObjSet, SRAParseObj,  XMLValidator
-from .utils import cmn, json2, logger, sanity_check_fail
+from .utils import cmn, json2, logger
 from .validate_json import JsonSchema
 from .ihec_validator_base import  IHECJsonValidator
 from . import exp_semantic_rules
 from . import validate_main
+from . import utils
 
 
 class ExperimentValidator(IHECJsonValidator):
@@ -60,9 +61,9 @@ def main(args):
 		sra = SRAParseObjSet.from_file(e)
 		nObjs += sra.nOffspring()
 		if not sra.xml.getroot().tag == objset:
-			sanity_check_fail('__unexpected_xmltype:' + e)
+			utils.sanity_check_fail('__unexpected_xmltype:' + e)
 		if not sra.is_valid__xml(xml_validator) or args.has("-not-sra-xml-but-try"):
-			sanity_check_fail('__invalid_xml:' + e)
+			utils.sanity_check_fail('__invalid_xml:' + e)
 		v = ExperimentValidator(sra, ihec_validators)
 		validated.extend(v.is_valid_ihec())
 		expvalidator[e] = v
@@ -78,7 +79,3 @@ def main(args):
 	
 
 	return validate_main.main(args, versioned_xml, validated, nObjs, expvalidator, xml_validator)
-
-
-
-

--- a/version_metadata/validate_experiment.py
+++ b/version_metadata/validate_experiment.py
@@ -1,5 +1,5 @@
 from .sraparse import SRAParseObjSet, SRAParseObj,  XMLValidator
-from .utils import cmn, json2, logger
+from .utils import cmn, json2, logger, sanity_check_fail
 from .validate_json import JsonSchema
 from .ihec_validator_base import  IHECJsonValidator
 from . import exp_semantic_rules
@@ -60,9 +60,9 @@ def main(args):
 		sra = SRAParseObjSet.from_file(e)
 		nObjs += sra.nOffspring()
 		if not sra.xml.getroot().tag == objset:
-			utils.sanity_check_fail('__unexpected_xmltype:' + e)
+			sanity_check_fail('__unexpected_xmltype:' + e)
 		if not sra.is_valid__xml(xml_validator) or args.has("-not-sra-xml-but-try"):
-			utils.sanity_check_fail('__invalid_xml:' + e)
+			sanity_check_fail('__invalid_xml:' + e)
 		v = ExperimentValidator(sra, ihec_validators)
 		validated.extend(v.is_valid_ihec())
 		expvalidator[e] = v


### PR DESCRIPTION
* I saw the following error when my experiment XML is not valid:
```
Traceback (most recent call last):
  File "/Users/yunhailuo/anaconda3/envs/eu/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/yunhailuo/anaconda3/envs/eu/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/__main__.py", line 52, in <module>
    main(Config.sys())
  File "/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/__main__.py", line 41, in main
    validate_experiment.main(args) 
  File "/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/validate_experiment.py", line 65, in main
    utils.sanity_check_fail('__invalid_xml:' + e)
NameError: name 'utils' is not defined
```

* I saw following output which seems from schema loading not from validation. I find it's not very helpful and distracting.
```
{'if': {'properties': {'biomaterial_type': {'const': ['Cell Line']}}, 'required': ['biomaterial_type']}, 'then': {'properties': {'batch': {'description': 'The batch from which the cell line is derived. Primarily applicable to initial H1 cell line batches. NA if not applicable.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'differentiation_method': {'description': 'The protocol used to differentiation the cell line.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'differentiation_stage': {'description': 'The stage in cell differentiation to which the cell line belongs.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'line': {'description': 'The name of the cell line.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'lineage': {'description': 'The developmental lineage to which the cell line belongs.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'medium': {'description': 'The medium in which the cell line has been grown.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'passage': {'description': 'The number of times the cell line has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'sex': {'description': "'Male', 'Female', 'Unknown', or 'Mixed' for pooled samples.", 'items': {'enum': ['Male', 'Female', 'Unknown', 'Mixed'], 'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}}, 'required': ['line', 'lineage', 'differentiation_stage', 'differentiation_method', 'passage', 'medium', 'sex', 'batch']}}
{'if': {'properties': {'biomaterial_type': {'const': ['Primary Cell']}}, 'required': ['biomaterial_type']}, 'then': {'allOf': [{'$ref': 'file:/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/../schemas/json/2.0/sample.json#/definitions/donor'}], 'properties': {'cell_type': {'description': 'The type of cell.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'markers': {'description': 'Markers used to isolate and identify the cell type.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'origin_sample': {'description': 'Description of the origin tissue from which sample was extracted.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'origin_sample_ontology_curie': {'description': '(Ontology: UBERON) links to the tissue from which sample was extracted.', 'items': {'pattern': '^[A-Za-z]*:[A-Za-z0-9]*', 'type': 'string'}, 'minItems': 1, 'type': 'array'}, 'passage_if_expanded': {'description': 'If the primary cell has been expanded, the number of times the primary cell has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures. NA if no expansion.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}}, 'required': ['origin_sample_ontology_curie', 'origin_sample', 'cell_type', 'markers', 'passage_if_expanded']}}
{'if': {'properties': {'biomaterial_type': {'const': ['Primary Cell Culture']}}, 'required': ['biomaterial_type']}, 'then': {'allOf': [{'$ref': 'file:/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/../schemas/json/2.0/sample.json#/definitions/donor'}], 'properties': {'cell_type': {'description': '', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'culture_conditions': {'description': 'The conditions under which the primary cell was cultured.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'markers': {'description': 'Markers used to isolate and identify the cell type.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'origin_sample': {'description': 'Description of the origin tissue from which sample was extracted.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'origin_sample_ontology_curie': {'description': '(Ontology: UBERON) links to the tissue from which sample was extracted.', 'items': {'pattern': '^[A-Za-z]*:[A-Za-z0-9]*', 'type': 'string'}, 'minItems': 1, 'type': 'array'}, 'passage_if_expanded': {'description': 'If the primary cell culture has been expanded, the number of times the primary cell culture has been re-plated and allowed to grow back to confluency or to some maximum density if using suspension cultures. NA if no expansion.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}}, 'required': ['origin_sample_ontology_curie', 'origin_sample', 'cell_type', 'markers', 'culture_conditions', 'passage_if_expanded']}}
{'if': {'properties': {'biomaterial_type': {'const': ['Primary Tissue']}}, 'required': ['biomaterial_type']}, 'then': {'allOf': [{'$ref': 'file:/Users/yunhailuo/Github/ihec-ecosystems/version_metadata/../schemas/json/2.0/sample.json#/definitions/donor'}], 'properties': {'collection_method': {'description': 'The protocol for collecting the primary tissue.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'tissue_depot': {'description': 'Details about the anatomical location from which the primary tissue was collected.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}, 'tissue_type': {'description': 'The type of tissue.', 'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'}}, 'required': ['tissue_type', 'tissue_depot', 'collection_method']}}
```